### PR TITLE
Instantiate the application in the image to cache the weights.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY main.py .
 
+# Download and cache the model weights
+RUN python -c "import deepcell; deepcell.applications.MultiplexSegmentation()"
+
 ENTRYPOINT ["python", "main.py"]


### PR DESCRIPTION
Ideally, this PR will not be merged in, and the Application classes can rely on a `SavedModel` object instead of downloading weights files.

However, in the mean-time, this change can serve as a way to more quickly test the containers/applications.