### PR TITLE
Add `--squeeze` to all the child subparsers.

### DIFF
--- a/run_app.py
+++ b/run_app.py
@@ -80,7 +80,7 @@ def get_arg_parser():
                         choices=('DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL'),
                         help='Only log the given level and above.')
 
-    parser.add_argument('--squeeze', action='store_true',
+    parent.add_argument('--squeeze', action='store_true',
                         help='Squeeze the output tensor before saving.')
 
     # use subparsers to group options for different applications


### PR DESCRIPTION
`--squeeze` was added as an optional argument in #17, but it was added to the main argument parser instead of the parent. This means that the `mesmer` command does not recognize it.

This PR resolves the issue by adding it to the `parent` argparser instead of the primary one. This allows `mesmer` and all other subparsers to inherit the `--squeeze` arg.