### PR TITLE
Update docker image to use deepcell 0.10.0

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DEEPCELL_VERSION: 0.9.1
+      DEEPCELL_VERSION: 0.10.0
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
#18 updated the `deepcell` version in `requirements.txt` but did NOT update the version in the GHA release configuration. This means that the `0.2.x` builds are using deepcell 0.9.1 instead of the latest release 0.10.0.