### PR TITLE
Add "both" to the argument parser.

### DIFF
--- a/deepcell_applications/argparse.py
+++ b/deepcell_applications/argparse.py
@@ -120,7 +120,7 @@ def get_arg_parser():
                         help='Batch size for `model.predict`.')
 
     mesmer.add_argument('--compartment', '-c', default='whole-cell',
-                        choices=('nuclear', 'membrane', 'whole-cell'),
-                        help=('The cellular compartment to segment.'))
+                        choices=('nuclear', 'membrane', 'whole-cell', 'both'),
+                        help='The cellular compartment to segment.')
 
     return parser


### PR DESCRIPTION
Adds "both" as a valid value for `--compartment` to better match the model.

Fixes #24 