### PR TITLE
Pre-release updates

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      DEEPCELL_VERSION: 0.10.0
+      DEEPCELL_VERSION: 0.12.2
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use vanvalenlab/deepcell-tf as the base image
 # Change the build arg to edit the base image version.
-ARG DEEPCELL_VERSION=0.10.0-gpu
+ARG DEEPCELL_VERSION=0.12.2-gpu
 
 FROM vanvalenlab/deepcell-tf:${DEEPCELL_VERSION}
 


### PR DESCRIPTION
This bumps the deepcell docker version to 0.12.2 so that the image will work with the newest model. 