### PR TITLE
General maintenance of test infrastructure

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -43,7 +43,7 @@ jobs:
 
     - name: PyTest
       run: |
-        pytest deepcell_applications --cov deepcell_applications --pep8
+        pytest deepcell_applications --cov deepcell_applications
 
     - name: Coveralls
       if: env.COVERALLS_REPO_TOKEN != null

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v3

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,17 +13,3 @@ norecursedirs=
     build,
     .ipynb_checkpoints,
     docs
-
-# PEP-8 The following are ignored:
-# E501 line too long (82 > 79 characters)
-# E731 do not assign a lambda expression, use a def
-# W503 line break occurred before a binary operator
-
-pep8ignore=* E402 \
-           * E731 \
-           * W503 \
-           deepcell/datasets/* E501 \
-           deepcell/training.py E501
-
-# Enable line length testing with maximum line length of 99
-pep8maxlinelength = 99

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,11 +3,6 @@
 addopts=-v
         --durations=20
 
-# Ignore Deprecation Warnings
-filterwarnings =
-    ignore::DeprecationWarning
-    ignore::PendingDeprecationWarning
-
 # Do not run tests in the build folder
 norecursedirs=
     build,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,3 @@
-pytest<6
+pytest
 pytest-cov
 pytest-mock

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 pytest<6
-pytest-pep8
 pytest-cov
 pytest-mock


### PR DESCRIPTION
Similar to vanvalenlab/deepcell-tf#639, minus the explicit add for Python 3.10 support which will need to wait for another deepcell-tf release.