### PR TITLE
add imagecodecs and update deepcell-tf to 0.12.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use vanvalenlab/deepcell-tf as the base image
 # Change the build arg to edit the base image version.
-ARG DEEPCELL_VERSION=0.12.2-gpu
+ARG DEEPCELL_VERSION=0.12.4-gpu
 
 FROM vanvalenlab/deepcell-tf:${DEEPCELL_VERSION}
 

--- a/README.md
+++ b/README.md
@@ -119,3 +119,10 @@ This makes it simple to build a CPU-only version of the image or to build a new 
 # the -gpu tag is required to enable GPU compatibility when overriding versions
 docker build --build-arg DEEPCELL_VERSION=0.9.0-gpu -t vanvalenlab/deepcell-applications .
 ```
+
+
+### Changes 20230301
+
+* Add `imagecodec` for compatibility with LZW-compressed images
+* Update `deepcell` requirement to `0.12.4`
+* Update `deepcell-tf` base to `0.12.4`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-deepcell==0.12.2
+deepcell==0.12.4
 numpy
 tifffile
+imagecodecs


### PR DESCRIPTION
Added imagecodecs to requirement.txt to allow tiffile to load lzw-compressed images. Also some general update to the latest version of deepcell.