### PR TITLE
Bump dependencies to support compressed OME TIFs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ deepcell==0.12.2
 numpy
 tifffile
 imagecodecs
+# Temporary patch - remove when deepcell version is bumped to 0.12.5 or greater
+scikit-image==0.19.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 deepcell==0.12.2
 numpy
 tifffile
+imagecodecs


### PR DESCRIPTION
Closes #26 

Also includes a temporary pin for scikit-image to avoid issues with the latest release.