### PR TITLE
Rm scikit-image pin and bump deepcell-tf version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-deepcell==0.12.2
+deepcell>=0.12.5
 numpy
 tifffile
 imagecodecs
-# Temporary patch - remove when deepcell version is bumped to 0.12.5 or greater
-scikit-image==0.19.3


### PR DESCRIPTION
The scikit-image pin should no longer be necessary with the latest version of deepcell-tf.